### PR TITLE
having module register error/exception handlers in Module.php

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -16,12 +16,15 @@ class Module
         if(!$services->get('ZfBugsnag\Options\BugsnagOptions')->getEnabled())
             return;
 
-        $eventManager->attach('dispatch.error', function ($event) use ($services) {
-            $exception          =   $event->getResult()->exception;
+        $service            =   $services->get('BugsnagServiceException');
+        // Register the PHP exception and error handlers
+        $service->setupErrorHandlers();
+
+        $eventManager->attach('dispatch.error', function ($event) use ($services, $service) {
+            $exception      =   $event->getResult()->exception;
             // No exception, stop the script
             if (!$exception) return;
 
-            $service            =   $services->get('BugsnagServiceException');
             $service->sendException($exception);
         });
     }

--- a/config/zfbugsnag.local.php
+++ b/config/zfbugsnag.local.php
@@ -42,5 +42,13 @@ return [
 		 * Default: true
 		 */
 		'autoNotify' => true,
+
+		/**
+		 * appVersion
+		 * The version of the application that will be sent to BugSnag,
+		 * useful when fixing errors so Bugsnag reports errors if they appear
+		 * in a new version of the app.
+		 */
+		'appVersion' => '1.0.0'
 	],
 ];

--- a/src/ZfBugsnag/Options/BugsnagOptions.php
+++ b/src/ZfBugsnag/Options/BugsnagOptions.php
@@ -72,6 +72,15 @@ class BugsnagOptions extends AbstractOptions
     }
 
     /**
+     * appVersion
+     * @param String $appVersion
+     */
+    public function setAppVersion($appVersion)
+    {
+        $this->appVersion = $appVersion;
+    }
+
+    /**
      * getApiKey
      * @return String $apiKey
      */
@@ -81,7 +90,7 @@ class BugsnagOptions extends AbstractOptions
     }
 
     /**
-     * getEnabled 
+     * getEnabled
      * @return Boolean $isEnabled
      */
     public function getEnabled()
@@ -123,5 +132,14 @@ class BugsnagOptions extends AbstractOptions
     public function getSendEnvironment()
     {
         return $this->sendEnvironment;
+    }
+
+    /**
+     * getAppVersion
+     * @return String $appVersion
+     */
+    public function getAppVersion()
+    {
+        return $this->appVersion;
     }
 }

--- a/src/ZfBugsnag/Options/BugsnagOptions.php
+++ b/src/ZfBugsnag/Options/BugsnagOptions.php
@@ -17,6 +17,8 @@ class BugsnagOptions extends AbstractOptions
 
     protected $sendEnvironment;
 
+    protected $appVersion;
+
     /**
      * setApiKey
      * @param String $apiKey
@@ -63,7 +65,7 @@ class BugsnagOptions extends AbstractOptions
     }
 
     /**
-     * sendEnvironment
+     * setSendEnvironment
      * @param Boolean $sendEnvironment
      */
     public function setSendEnvironment($sendEnvironment)
@@ -72,7 +74,7 @@ class BugsnagOptions extends AbstractOptions
     }
 
     /**
-     * appVersion
+     * setAppVersion
      * @param String $appVersion
      */
     public function setAppVersion($appVersion)

--- a/src/ZfBugsnag/Service/BugsnagService.php
+++ b/src/ZfBugsnag/Service/BugsnagService.php
@@ -6,6 +6,9 @@ use \Bugsnag;
 class BugsnagService
 {
     protected $options;
+    protected $bugsnag;
+    protected $oldErrorHandler;
+    protected $oldExceptionHandler;
 
     /**
      * __construct
@@ -13,15 +16,109 @@ class BugsnagService
      *
      * @param Object \ZfBugsnag\Options\BugsnagOptions
      */
-    public function __construct(\ZfBugsnag\Options\BugsnagOptions $options) 
+    public function __construct(\ZfBugsnag\Options\BugsnagOptions $options)
     {
         $this->options = $options;
+
+        if($this->options->getEnabled())
+        {
+            $this->bugsnag        = new \Bugsnag_Client($this->options->getApiKey());
+            $this->bugsnag->setReleaseStage($this->options->getReleaseStage());
+            $this->bugsnag->setNotifyReleaseStages($this->options->getNotifyReleaseStages());
+            $this->bugsnag->setBeforeNotifyFunction([$this, 'beforeNotify']);
+            $this->bugsnag->setNotifier([
+                'name'    =>    'ZfBugsnag',
+                'version' =>    \ZfBugsnag\Version::VERSION,
+                'url'     =>    'https://github.com/nickurt/zf-bugsnag'
+            ]);
+            if($this->options->getAppVersion())
+            {
+                $this->bugsnag->setAppVersion($this->options->getAppVersion());
+            }
+            $this->bugsnag->setAutoNotify($this->options->getAutoNotify());
+            $this->bugsnag->setSendEnvironment($this->options->getSendEnvironment());
+        }
+    }
+
+    /**
+     * setupErrorHandlers
+     * Registers the exception and error handlers with PHP
+     *
+     */
+    public function setupErrorHandlers()
+    {
+        if($this->options->getEnabled())
+        {
+            $this->oldErrorHandler     = set_error_handler([$this, 'errorHandler']);
+            $this->oldExceptionHandler = set_exception_handler([$this, 'exceptionHandler']);
+        }
+    }
+
+    /**
+     * errorHandler
+     * Handles PHP errors and sends them to Bugsnag, will call existing error handler
+     * if one was defined.
+     *
+     * @param Integer $errno Error number
+     * @param String $errsrt Error message
+     * @param String $errfile File where error occurred
+     * @param Integer $errline Line number where error occurred
+     * @param Array $errcontext Error's context
+     */
+    public function errorHandler($errno, $errstr, $errfile = '', $errline = 0, $errcontext = [])
+    {
+        $result = $this->bugsnag->errorHandler($errno, $errstr, $errfile, $errline);
+
+        if($this->oldErrorHandler)
+        {
+            return call_user_func($this->oldErrorHandler, $errno, $errstr, $errfile, $errline, $errcontext);
+        }
+
+        return $result;
+    }
+
+    /**
+     * exceptionHandler
+     * Handles uncaught Exceptions and sends them to Bugsnag, will call existing exception handler
+     * if one was defined.
+     *
+     * @param object \Exception $exception The exception to pass
+     */
+    public function exceptionHandler($exception)
+    {
+        $result = $this->bugsnag->exceptionHandler($exception);
+
+        if($this->oldExceptionHandler)
+        {
+            return call_user_func($this->oldExceptionHandler, $exception);
+        }
+
+        return $result;
+    }
+
+    /**
+     * beforeNotify
+     * This method is called before notifying Bugsnag and will remove a stack frame if that frame
+     * matches this class' error/exception handling methods. This makes sure the errors get grouped
+     * better in the BugSnag UI, otherwise they'll all get grouped under either the exception handler
+     * or the error handler, depending on which one sent it.
+     *
+     * @param object \Bugsnag_Error $error The Bugsnag_Error object that BugSnag will pass in
+     */
+    public function beforeNotify(\Bugsnag_Error $error)
+    {
+        $firstFrame = $error->stacktrace->frames[0];
+
+        if($firstFrame && ($firstFrame['method'] === get_class() . '::errorHandler' || $firstFrame['method'] === get_class() . '::exceptionHandler'))
+        {
+            array_splice($error->stacktrace->frames, 0, 1);
+        }
     }
 
     /**
      * sendException
-     * Send the Exception to the Bugsnag Servers 
-     * 
+     * Send the Exception to the Bugsnag Servers
+     *
      * @param object \Exception $e
      */
     public function sendException(\Exception $e)
@@ -29,25 +126,8 @@ class BugsnagService
         // Check if we have to send the Exception
         if($this->options->getEnabled())
         {
-            // Bugsnag
-            $bugsnag        = new \Bugsnag_Client($this->options->getApiKey());
-            $bugsnag->setReleaseStage($this->options->getReleaseStage());
-            $bugsnag->setNotifyReleaseStages($this->options->getNotifyReleaseStages());
-            $bugsnag->setNotifier([
-                'name'    =>    'ZfBugsnag',
-                'version' =>    \ZfBugsnag\Version::VERSION,
-                'url'     =>    'https://github.com/nickurt/zf-bugsnag'
-            ]);
-            $bugsnag->setAppVersion(\ZfBugsnag\Version::VERSION);
-            $bugsnag->setAutoNotify($this->options->getAutoNotify());
-            $bugsnag->setSendEnvironment($this->options->getSendEnvironment());
-
-            // Set the handler for the exceptions
-            set_error_handler(array($bugsnag, 'errorHandler'));
-            set_exception_handler(array($bugsnag, 'exceptionHandler'));
-
             // Send it
-            $bugsnag->notifyException($e);
+            $this->bugsnag->notifyException($e);
         }
     }
 }


### PR DESCRIPTION
Previously, this module was registering the error and
exception handlers in the sendException call, which is only ever called
when a `dispatch.error` is handled.  For most apps, this is probably
already too late to register exception/error handlers.  Plus, if an app
never encounters a `dispatch.error` event, the handlers will never be
registered, so any errors/exceptions that don’t trigger a
`dispatch.error` wouldn’t get sent to Bugsnag.

Moving the registration of these handlers to the onBootstrap method of
Module.php, which should get them registered pretty early in the app’s
lifecycle.

Tested that errors and exceptions that don’t trigger a `dispatch.error`
event are caught by the handlers, and sent to BugSnag.